### PR TITLE
feat: stream thinking from SDK to iOS and web clients

### DIFF
--- a/clients/ios/Netclode/Features/Chat/ToolEventCard.swift
+++ b/clients/ios/Netclode/Features/Chat/ToolEventCard.swift
@@ -514,25 +514,59 @@ struct FileChangeCard: View {
 
 struct ThinkingCard: View {
     let event: ThinkingEvent
+    @State private var isExpanded = false
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.sm) {
-            Image(systemName: "brain.head.profile")
-                .font(.system(size: 12))
-                .foregroundStyle(Theme.Colors.brandLight)
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            // Header row with icon and status
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: "brain.head.profile")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Theme.Colors.brandLight)
+                    .opacity(event.partial ? 1.0 : 0.7)
 
+                Text("Thinking")
+                    .font(.netclodeCaption)
+                    .fontWeight(.medium)
+                    .foregroundStyle(Theme.Colors.brandLight)
+
+                if event.partial {
+                    // Pulsing indicator for streaming
+                    Circle()
+                        .fill(Theme.Colors.brandLight)
+                        .frame(width: 6, height: 6)
+                        .opacity(0.8)
+                }
+
+                Spacer()
+
+                if !event.partial && event.content.count > 100 {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            isExpanded.toggle()
+                        }
+                    } label: {
+                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            // Content
             Text(event.content)
                 .font(.netclodeCaption)
                 .foregroundStyle(.secondary)
                 .italic()
-                .lineLimit(2)
-
-            Spacer()
+                .lineLimit(isExpanded || event.partial ? nil : 3)
+                .animation(.easeInOut(duration: 0.2), value: event.content)
         }
         .padding(.horizontal, Theme.Spacing.sm)
         .padding(.vertical, Theme.Spacing.xs)
-        .background(Theme.Colors.brandLight.opacity(0.1))
+        .background(Theme.Colors.brandLight.opacity(event.partial ? 0.15 : 0.1))
         .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.sm))
+        .animation(.easeInOut(duration: 0.2), value: event.partial)
     }
 }
 

--- a/clients/ios/Netclode/Models/AgentEvent.swift
+++ b/clients/ios/Netclode/Models/AgentEvent.swift
@@ -185,7 +185,9 @@ struct ThinkingEvent: AgentEventProtocol {
     let id: UUID
     let kind: AgentEventKind = .thinking
     let timestamp: Date
-    let content: String
+    let thinkingId: String  // Correlate streaming updates for same thinking block
+    var content: String     // Mutable to accumulate streaming content
+    let partial: Bool       // true = streaming delta, false = complete block
 }
 
 struct PortExposedEvent: AgentEventProtocol {
@@ -302,7 +304,9 @@ extension AgentEvent {
     static let previewThinking = AgentEvent.thinking(ThinkingEvent(
         id: UUID(),
         timestamp: Date(),
-        content: "Analyzing the codebase structure..."
+        thinkingId: "thinking_preview_1",
+        content: "Analyzing the codebase structure...",
+        partial: false
     ))
 
     static let previewList: [AgentEvent] = [

--- a/clients/ios/Netclode/Models/ServerMessage.swift
+++ b/clients/ios/Netclode/Models/ServerMessage.swift
@@ -156,6 +156,8 @@ private struct RawAgentEvent: Decodable {
 
     // Thinking
     let content: String?
+    let thinkingId: String?
+    let partial: Bool?
 
     // Port detected
     let port: Int?
@@ -233,7 +235,9 @@ private struct RawAgentEvent: Decodable {
             return .thinking(ThinkingEvent(
                 id: id,
                 timestamp: timestamp,
-                content: content ?? ""
+                thinkingId: thinkingId ?? "thinking_\(id.uuidString)",
+                content: content ?? "",
+                partial: partial ?? false
             ))
 
         case "port_exposed":
@@ -249,7 +253,9 @@ private struct RawAgentEvent: Decodable {
             return .thinking(ThinkingEvent(
                 id: id,
                 timestamp: timestamp,
-                content: "Unknown event: \(kind)"
+                thinkingId: "unknown_\(id.uuidString)",
+                content: "Unknown event: \(kind)",
+                partial: false
             ))
         }
     }

--- a/clients/ios/Netclode/Services/MessageRouter.swift
+++ b/clients/ios/Netclode/Services/MessageRouter.swift
@@ -82,7 +82,23 @@ final class MessageRouter {
             sessionStore.setProcessing(for: sessionId, processing: true)
 
         case .agentEvent(let sessionId, let event):
-            eventStore.appendEvent(sessionId: sessionId, event: event)
+            // Handle thinking events specially for streaming
+            if case .thinking(let thinkingEvent) = event {
+                if thinkingEvent.partial {
+                    // Streaming thinking - accumulate content
+                    eventStore.appendThinkingPartial(
+                        sessionId: sessionId,
+                        thinkingId: thinkingEvent.thinkingId,
+                        content: thinkingEvent.content,
+                        timestamp: thinkingEvent.timestamp
+                    )
+                } else {
+                    // Complete thinking block - add as final event
+                    eventStore.appendEvent(sessionId: sessionId, event: event)
+                }
+            } else {
+                eventStore.appendEvent(sessionId: sessionId, event: event)
+            }
 
         case .agentDone(let sessionId):
             sessionStore.setProcessing(for: sessionId, processing: false)

--- a/clients/ios/Netclode/Stores/EventStore.swift
+++ b/clients/ios/Netclode/Stores/EventStore.swift
@@ -27,6 +27,62 @@ final class EventStore {
         eventsBySession[sessionId] = events
     }
 
+    /// Append partial thinking content or create a new thinking event
+    func appendThinkingPartial(sessionId: String, thinkingId: String, content: String, timestamp: Date) {
+        var events = eventsBySession[sessionId] ?? []
+
+        // Find existing thinking event with this thinkingId
+        if let existingIndex = events.lastIndex(where: { event in
+            if case .thinking(let e) = event, e.thinkingId == thinkingId {
+                return true
+            }
+            return false
+        }) {
+            // Update existing thinking event by appending content
+            if case .thinking(var thinkingEvent) = events[existingIndex] {
+                thinkingEvent.content += content
+                events[existingIndex] = .thinking(thinkingEvent)
+            }
+        } else {
+            // Create new thinking event
+            let newEvent = ThinkingEvent(
+                id: UUID(),
+                timestamp: timestamp,
+                thinkingId: thinkingId,
+                content: content,
+                partial: true
+            )
+            events.append(.thinking(newEvent))
+        }
+
+        eventsBySession[sessionId] = events
+    }
+
+    /// Finalize a thinking event (mark as complete)
+    func finalizeThinking(sessionId: String, thinkingId: String) {
+        guard var events = eventsBySession[sessionId] else { return }
+
+        if let index = events.lastIndex(where: { event in
+            if case .thinking(let e) = event, e.thinkingId == thinkingId {
+                return true
+            }
+            return false
+        }) {
+            if case .thinking(var thinkingEvent) = events[index] {
+                // Create a new event with partial = false
+                let finalizedEvent = ThinkingEvent(
+                    id: thinkingEvent.id,
+                    timestamp: thinkingEvent.timestamp,
+                    thinkingId: thinkingEvent.thinkingId,
+                    content: thinkingEvent.content,
+                    partial: false
+                )
+                events[index] = .thinking(finalizedEvent)
+                eventsBySession[sessionId] = events
+            }
+        }
+    }
+
     func clearEvents(for sessionId: String) {
         eventsBySession.removeValue(forKey: sessionId)
     }

--- a/clients/web/src/components/ChatPanel.tsx
+++ b/clients/web/src/components/ChatPanel.tsx
@@ -120,7 +120,22 @@ function EventDetails({ event }: { event: AgentEvent }) {
     case "thinking":
       return (
         <Box p="xs">
-          <Text size="xs" c="dimmed" style={{ whiteSpace: "pre-wrap", fontStyle: "italic" }}>
+          <Group gap="xs" mb={4}>
+            <Text size="xs" fw={500} c="grape">Thinking</Text>
+            {event.partial && (
+              <Loader size={10} color="grape" />
+            )}
+          </Group>
+          <Text 
+            size="xs" 
+            c="dimmed" 
+            style={{ 
+              whiteSpace: "pre-wrap", 
+              fontStyle: "italic",
+              maxHeight: 200,
+              overflow: "auto",
+            }}
+          >
             {event.content}
           </Text>
         </Box>
@@ -248,13 +263,14 @@ function InlineToolEvent({ event }: { event: AgentEvent }) {
       case "file_change": return `${event.action} ${event.path.split("/").pop()}`;
       case "command_start": return `Running command`;
       case "command_end": return `Command ${event.exitCode === 0 ? "completed" : "failed"}`;
-      case "thinking": return "Thinking...";
+      case "thinking": return event.partial ? "Thinking..." : "Thought";
       case "port_exposed": return `Port ${event.port} opened`;
       default: return String((event as { kind: string }).kind);
     }
   };
 
-  const isInProgress = event.kind === "tool_start" || event.kind === "command_start";
+  const isInProgress = event.kind === "tool_start" || event.kind === "command_start" || 
+                       (event.kind === "thinking" && event.partial);
   const isError = (event.kind === "tool_end" && event.error) ||
                   (event.kind === "command_end" && event.exitCode !== 0);
 

--- a/clients/web/src/pages/WorkspacePage.tsx
+++ b/clients/web/src/pages/WorkspacePage.tsx
@@ -85,7 +85,34 @@ export function WorkspacePage() {
         case "agent.event":
           if (msg.sessionId === id) {
             updateCursor(msg.id);
-            setEvents((prev) => [...prev, msg.event]);
+            const event = msg.event;
+            
+            // Handle streaming thinking events - accumulate content by thinkingId
+            if (event.kind === "thinking" && event.thinkingId && event.partial) {
+              setEvents((prev) => {
+                const existingIndex = prev.findIndex(
+                  (e) => e.kind === "thinking" && e.thinkingId === event.thinkingId
+                );
+                if (existingIndex >= 0) {
+                  // Append to existing thinking event
+                  const updated = [...prev];
+                  const existing = updated[existingIndex];
+                  if (existing.kind === "thinking") {
+                    updated[existingIndex] = {
+                      ...existing,
+                      content: existing.content + event.content,
+                    };
+                  }
+                  return updated;
+                } else {
+                  // New thinking event
+                  return [...prev, event];
+                }
+              });
+            } else {
+              // Non-thinking events or complete thinking blocks
+              setEvents((prev) => [...prev, event]);
+            }
           }
           break;
         case "agent.done":

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -59,7 +59,9 @@ export interface CommandEndEvent extends BaseAgentEvent {
 
 export interface ThinkingEvent extends BaseAgentEvent {
   kind: "thinking";
+  thinkingId: string; // Correlate streaming updates for same thinking block
   content: string;
+  partial: boolean; // true = streaming delta, false = complete block
 }
 
 export interface PortExposedEvent extends BaseAgentEvent {

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -114,7 +114,7 @@ const q = query({
 });
 
 for await (const message of q) {
-  // system, assistant, user, result, stream_event
+  // system, assistant (text, tool_use, thinking), user, result, stream_event
 }
 ```
 
@@ -194,6 +194,40 @@ docker build -t ghcr.io/angristan/netclode-agent:latest -f services/agent/Docker
 ```
 
 Includes Debian bookworm-slim, Node.js via mise, Docker, Git, curl, build-essential, Claude CLI.
+
+## SSE Event Types
+
+Events streamed via Server-Sent Events during prompt execution:
+
+| Type | Description |
+|------|-------------|
+| `start` | Prompt execution started |
+| `agent.system` | SDK system message (init, session ID) |
+| `agent.message` | Text content from Claude (`partial: true` for streaming) |
+| `agent.event` | Tool/command events (see below) |
+| `agent.result` | Final result with `numTurns` and `costUsd` |
+| `done` | Prompt execution completed |
+| `error` | Error occurred |
+
+### Agent Events (`agent.event`)
+
+| Event Kind | Description | Fields |
+|------------|-------------|--------|
+| `tool_start` | Tool invocation started | `tool`, `toolUseId`, `input` |
+| `tool_input` | Streaming tool input | `toolUseId`, `inputDelta` |
+| `tool_end` | Tool completed | `tool`, `toolUseId`, `result?`, `error?` |
+| `thinking` | Extended thinking content | `thinkingId`, `content`, `partial` |
+
+All events include a `timestamp` field (ISO 8601).
+
+### Thinking Events
+
+When using models that support extended thinking (e.g., `claude-opus-4-5-20251101`), the agent streams thinking content in real-time:
+
+- `partial: true` - Streaming delta (accumulate by `thinkingId`)
+- `partial: false` - Complete thinking block
+
+Clients should accumulate content for events with the same `thinkingId` to build up the full thinking output.
 
 ## Debugging
 

--- a/services/agent/src/index.ts
+++ b/services/agent/src/index.ts
@@ -150,6 +150,24 @@ const toolNameMap = new Map<string, string>();
 // Track current content block index to toolUseId mapping for streaming
 const blockIndexToToolId = new Map<number, string>();
 
+// Track current content block index to thinkingId mapping for streaming thinking
+const blockIndexToThinkingId = new Map<number, string>();
+
+// Generate unique thinking IDs
+let thinkingIdCounter = 0;
+function generateThinkingId(): string {
+  return `thinking_${Date.now()}_${++thinkingIdCounter}`;
+}
+
+// Track current content block index to thinkingId mapping for streaming thinking
+const blockIndexToThinkingId = new Map<number, string>();
+
+// Generate unique thinking IDs
+let thinkingIdCounter = 0;
+function generateThinkingId(): string {
+  return `thinking_${Date.now()}_${++thinkingIdCounter}`;
+}
+
 const server = createServer(async (req, res) => {
   const url = new URL(req.url || "/", `http://localhost:${port}`);
   console.log(`[agent] ${req.method} ${url.pathname}`);
@@ -227,6 +245,20 @@ const server = createServer(async (req, res) => {
                 if (block.type === "text") {
                   console.log(`[agent] Text block: ${block.text.slice(0, 100)}...`);
                   send({ type: "agent.message", content: block.text, partial: false });
+                } else if (block.type === "thinking") {
+                  // Complete thinking block (extended thinking)
+                  const thinkingBlock = block as { type: "thinking"; thinking: string };
+                  console.log(`[agent] Thinking block: ${thinkingBlock.thinking.slice(0, 100)}...`);
+                  send({
+                    type: "agent.event",
+                    event: {
+                      kind: "thinking",
+                      thinkingId: generateThinkingId(),
+                      content: thinkingBlock.thinking,
+                      partial: false,
+                      timestamp: new Date().toISOString(),
+                    },
+                  });
                 } else if (block.type === "tool_use") {
                   console.log(`[agent] Tool use: ${block.name} (id=${block.id})`);
                   // Always store the tool name for later lookup in tool_result
@@ -290,6 +322,11 @@ const server = createServer(async (req, res) => {
                     timestamp: new Date().toISOString(),
                   },
                 });
+              } else if (contentBlock?.type === "thinking") {
+                // Start of a thinking block - generate ID and track it
+                const thinkingId = generateThinkingId();
+                blockIndexToThinkingId.set(message.event.index, thinkingId);
+                console.log(`[agent] Thinking block started: ${thinkingId}`);
               }
             } else if (message.event.type === "content_block_delta") {
               const delta = message.event.delta;
@@ -310,10 +347,27 @@ const server = createServer(async (req, res) => {
                     },
                   });
                 }
+              } else if (delta && "thinking" in delta) {
+                // Thinking content streaming (extended thinking)
+                const thinkingDelta = delta as { type: "thinking_delta"; thinking: string };
+                const thinkingId = blockIndexToThinkingId.get(message.event.index);
+                if (thinkingId) {
+                  send({
+                    type: "agent.event",
+                    event: {
+                      kind: "thinking",
+                      thinkingId,
+                      content: thinkingDelta.thinking,
+                      partial: true,
+                      timestamp: new Date().toISOString(),
+                    },
+                  });
+                }
               }
             } else if (message.event.type === "content_block_stop") {
-              // Clean up block index mapping
+              // Clean up block index mappings
               blockIndexToToolId.delete(message.event.index);
+              blockIndexToThinkingId.delete(message.event.index);
             }
             break;
         }

--- a/services/control-plane/internal/protocol/events.go
+++ b/services/control-plane/internal/protocol/events.go
@@ -18,24 +18,26 @@ const (
 
 // AgentEvent is a polymorphic event type. Fields are optional based on Kind.
 type AgentEvent struct {
-	Kind       AgentEventKind         `json:"kind"`
-	Timestamp  string                 `json:"timestamp"`
-	Tool       string                 `json:"tool,omitempty"`
-	ToolUseID  string                 `json:"toolUseId,omitempty"`
-	Input      map[string]interface{} `json:"input,omitempty"`
-	InputDelta string                 `json:"inputDelta,omitempty"`
-	Result     *string                `json:"result,omitempty"`
-	Error      *string                `json:"error,omitempty"`
-	Path      string                 `json:"path,omitempty"`
-	Action    string                 `json:"action,omitempty"`
-	Command   string                 `json:"command,omitempty"`
-	Cwd       *string                `json:"cwd,omitempty"`
-	ExitCode  *int                   `json:"exitCode,omitempty"`
-	Output    *string                `json:"output,omitempty"`
-	Content   string                 `json:"content,omitempty"`
-	Port      int                    `json:"port,omitempty"`
-	Process   *string                `json:"process,omitempty"`
-	PreviewURL *string               `json:"previewUrl,omitempty"`
-	LinesAdded   *int                `json:"linesAdded,omitempty"`
-	LinesRemoved *int                `json:"linesRemoved,omitempty"`
+	Kind         AgentEventKind         `json:"kind"`
+	Timestamp    string                 `json:"timestamp"`
+	Tool         string                 `json:"tool,omitempty"`
+	ToolUseID    string                 `json:"toolUseId,omitempty"`
+	Input        map[string]interface{} `json:"input,omitempty"`
+	InputDelta   string                 `json:"inputDelta,omitempty"`
+	Result       *string                `json:"result,omitempty"`
+	Error        *string                `json:"error,omitempty"`
+	Path         string                 `json:"path,omitempty"`
+	Action       string                 `json:"action,omitempty"`
+	Command      string                 `json:"command,omitempty"`
+	Cwd          *string                `json:"cwd,omitempty"`
+	ExitCode     *int                   `json:"exitCode,omitempty"`
+	Output       *string                `json:"output,omitempty"`
+	Content      string                 `json:"content,omitempty"`
+	ThinkingID   string                 `json:"thinkingId,omitempty"` // Correlate streaming thinking updates
+	Partial      bool                   `json:"partial,omitempty"`    // true for streaming thinking deltas
+	Port         int                    `json:"port,omitempty"`
+	Process      *string                `json:"process,omitempty"`
+	PreviewURL   *string                `json:"previewUrl,omitempty"`
+	LinesAdded   *int                   `json:"linesAdded,omitempty"`
+	LinesRemoved *int                   `json:"linesRemoved,omitempty"`
 }

--- a/services/control-plane/internal/session/agent.go
+++ b/services/control-plane/internal/session/agent.go
@@ -287,6 +287,12 @@ func parseAgentEvent(data map[string]interface{}) protocol.AgentEvent {
 	if content, ok := data["content"].(string); ok {
 		event.Content = content
 	}
+	if thinkingID, ok := data["thinkingId"].(string); ok {
+		event.ThinkingID = thinkingID
+	}
+	if partial, ok := data["partial"].(bool); ok {
+		event.Partial = partial
+	}
 
 	// Port detected events
 	if port, ok := data["port"].(float64); ok {


### PR DESCRIPTION
## Summary

Add support for streaming extended thinking content from the Claude Agent SDK to iOS and web clients.

- Protocol: Add `thinkingId` and `partial` fields to `ThinkingEvent`
- Agent: Handle `thinking` content blocks and `thinking_delta` stream events
- Control-plane: Parse new `ThinkingID` and `Partial` fields
- iOS: Accumulate streaming thinking by `thinkingId`, enhanced `ThinkingCard` UI
- Web: Accumulate thinking events, show streaming indicator

Thinking content streams in real-time with `partial=true` events, allowing clients to display Claude's reasoning as it happens.