### PR TITLE
fix: delete correct NetworkPolicy name on session cleanup

### DIFF
--- a/services/control-plane/internal/k8s/sandbox.go
+++ b/services/control-plane/internal/k8s/sandbox.go
@@ -1142,11 +1142,11 @@ func (r *k8sRuntime) ConfigureTailnetAccess(ctx context.Context, sessionID strin
 // DeleteNetworkRestriction removes any network restriction and tailnet access policies for a session.
 // This is called during sandbox cleanup.
 func (r *k8sRuntime) DeleteNetworkRestriction(ctx context.Context, sessionID string) error {
-	// Delete network restriction policy
-	restrictPolicyName := fmt.Sprintf("sess-%s-network-restrict", sessionID)
-	err := r.clientset.NetworkingV1().NetworkPolicies(r.namespace).Delete(ctx, restrictPolicyName, metav1.DeleteOptions{})
+	// Delete internet access policy (created by ConfigureNetwork)
+	internetPolicyName := fmt.Sprintf("sess-%s-internet-access", sessionID)
+	err := r.clientset.NetworkingV1().NetworkPolicies(r.namespace).Delete(ctx, internetPolicyName, metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("delete network restriction policy: %w", err)
+		return fmt.Errorf("delete internet access policy: %w", err)
 	}
 
 	// Delete tailnet access policy


### PR DESCRIPTION
## Summary

- `DeleteNetworkRestriction` was deleting `sess-<id>-network-restrict` but `ConfigureNetwork` creates the policy as `sess-<id>-internet-access`. This caused internet-access egress policies to leak on every session pause/delete, accumulating orphaned NetworkPolicies over time.

## Details

`ConfigureNetwork` (line 981):
```go
internetPolicyName := fmt.Sprintf("sess-%s-internet-access", sessionID)
```

`DeleteNetworkRestriction` (old, line 1146):
```go
restrictPolicyName := fmt.Sprintf("sess-%s-network-restrict", sessionID) // wrong name
```

The tailnet policy name (`sess-%s-tailnet-access`) was already correct.

## Test plan

- [x] `go build ./services/control-plane/...`
- [x] `go test ./services/control-plane/...`
- [ ] After deploy, verify orphaned policies are cleaned up on session delete: `kubectl --context netclode -n netclode get networkpolicies`